### PR TITLE
✨ When logging exceptions put stack trace in it's own array entry

### DIFF
--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -218,7 +218,7 @@ class ExceptionHandler extends Handler
             return;
         }
 
-        $this->logger->error($e->getMessage(), $e->getTrace());
+        $this->logger->error($e->getMessage(), ['trace' => $e->getTrace()]);
     }
 
     /**

--- a/tests/ExceptionHandlerTest.php
+++ b/tests/ExceptionHandlerTest.php
@@ -143,7 +143,7 @@ class ExceptionHandlerTest extends TestCase
         }
 
         $logger = Mockery::mock(LoggerInterface::class);
-        $logger->shouldReceive('error')->withArgs([$message, $trace]);
+        $logger->shouldReceive('error')->withArgs([$message, ['trace' => $trace]]);
 
         try {
             $this->handler->setLogger($logger);
@@ -167,7 +167,7 @@ class ExceptionHandlerTest extends TestCase
         });
 
         $logger = Mockery::mock(LoggerInterface::class);
-        $logger->shouldReceive('error')->withArgs([$exception->getMessage(), $exception->getTrace()]);
+        $logger->shouldReceive('error')->withArgs([$exception->getMessage(), ['trace' => $exception->getTrace()]]);
 
         $this->handler->setNewrelic($newRelic)->setLogger($logger)->report($exception);
     }


### PR DESCRIPTION
When logging an exception, the entire trace was merged with the remaining context, which causes the logs to be unreadable.

Please release this as v0.4.3.