### PR TITLE
MP-1455 Added carrier_status to CarrierApiException meta.

### DIFF
--- a/src/Exceptions/CarrierApiException.php
+++ b/src/Exceptions/CarrierApiException.php
@@ -24,5 +24,6 @@ class CarrierApiException extends AbstractException
         );
 
         $this->addMeta('carrier_response', $carrierApiResponse);
+        $this->addMeta('carrier_status', $status);
     }
 }

--- a/tests/Exceptions/ExceptionsTest.php
+++ b/tests/Exceptions/ExceptionsTest.php
@@ -43,7 +43,10 @@ class ExceptionsTest extends TestCase
         $exception = new CarrierApiException(418, ['teapot'], new Exception('HTCPCP'));
 
         $this->assertEquals(418, $exception->getStatus());
-        $this->assertEquals(['carrier_response' => ['teapot']], $exception->getMeta());
+        $this->assertEquals([
+            'carrier_response' => ['teapot'],
+            'carrier_status'   => 418,
+        ], $exception->getMeta());
         $this->assertEquals('HTCPCP', $exception->getPrevious()->getMessage());
     }
 


### PR DESCRIPTION
**Changes**
- Added `carrier_status` to CarrierApiException meta.

**Related Issues**
- https://myparcelcombv.atlassian.net/browse/MP-1455