### PR TITLE
Map method not allowed exception

### DIFF
--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -18,6 +18,8 @@ use MyParcelCom\JsonApi\Exceptions\NotFoundException;
 use MyParcelCom\JsonApi\Transformers\ErrorTransformer;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+use MyParcelCom\JsonApi\Exceptions\MethodNotAllowedException;
 
 class ExceptionHandler extends Handler
 {
@@ -122,6 +124,10 @@ class ExceptionHandler extends Handler
 
         if ($exception instanceof NotFoundHttpException) {
             $exception = new NotFoundException('The endpoint could not be found.');
+        }
+
+        if ($exception instanceof MethodNotAllowedHttpException) {
+            $exception = new MethodNotAllowedException($request->getMethod());
         }
 
         if ($exception instanceof MultiErrorInterface) {

--- a/src/Exceptions/Interfaces/ExceptionInterface.php
+++ b/src/Exceptions/Interfaces/ExceptionInterface.php
@@ -52,6 +52,11 @@ interface ExceptionInterface extends JsonSchemaErrorInterface
         'title' => 'Unprocessable entity',
     ];
 
+    const METHOD_NOT_ALLOWED = [
+        'code'  => '10009',
+        'title' => 'Method not allowed',
+    ];
+
     // Billing/payment related errors 11000 - 11999
     const MISSING_BILLING_INFORMATION = [
         'code'  => '11000',

--- a/src/Exceptions/MethodNotAllowedException.php
+++ b/src/Exceptions/MethodNotAllowedException.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\JsonApi\Exceptions;
+
+/**
+ * This exception is thrown when an endpoint
+ * does not support the http method used to
+ * call the endpoint.
+ *
+ * For example:
+ * A `PUT` request is made to `/some-endpoint`, but
+ * `/some-endpoint` only supports GET requests
+ */
+class MethodNotAllowedException extends AbstractException
+{
+    public function __construct(string $httpMethod, \Throwable $previous = null)
+    {
+        $httpMethod = strtoupper($httpMethod);
+        parent::__construct(
+            "The '{$httpMethod}' method is not allowed on this endpoint.",
+            self::METHOD_NOT_ALLOWED,
+            405,
+            $previous
+        );
+    }
+}

--- a/tests/Exceptions/ExceptionsTest.php
+++ b/tests/Exceptions/ExceptionsTest.php
@@ -15,6 +15,7 @@ use MyParcelCom\JsonApi\Exceptions\InvalidHeaderException;
 use MyParcelCom\JsonApi\Exceptions\InvalidJsonSchemaException;
 use MyParcelCom\JsonApi\Exceptions\InvalidScopeException;
 use MyParcelCom\JsonApi\Exceptions\InvalidSecretException;
+use MyParcelCom\JsonApi\Exceptions\MethodNotAllowedException;
 use MyParcelCom\JsonApi\Exceptions\MissingScopeException;
 use MyParcelCom\JsonApi\Exceptions\MissingTokenException;
 use MyParcelCom\JsonApi\Exceptions\ModelTypeException;
@@ -191,5 +192,16 @@ class ExceptionsTest extends TestCase
 
         $this->assertEquals('G-Star', $exception->getPrevious()->getMessage());
         $this->assertEquals('RAW', $exception->getMessage());
+    }
+
+    /** @test */
+    public function testMethodNotAllowedException()
+    {
+        $exception = new MethodNotAllowedException('Put', new Exception('Previous exception'));
+
+        $this->assertEquals(405, $exception->getStatus());
+        $this->assertEquals(10009, $exception->getCode());
+        $this->assertEquals('The \'PUT\' method is not allowed on this endpoint.', $exception->getMessage());
+        $this->assertEquals('Previous exception', $exception->getPrevious()->getMessage());
     }
 }


### PR DESCRIPTION
**Changes**
- Map the `MethodNotAllowedHttpException` thrown by Laravel to a custom `MethodNotAllowedException`

**Related issues**
- https://myparcelcombv.atlassian.net/browse/MP-1373