### PR TITLE
Fixed incorrect error status type

### DIFF
--- a/src/Transformers/ErrorTransformer.php
+++ b/src/Transformers/ErrorTransformer.php
@@ -18,12 +18,12 @@ class ErrorTransformer
     {
         return array_filter(
             [
-                'id'     => $exception->getId(),
+                'id'     => (string)$exception->getId(),
                 'links'  => $exception->getLinks(),
-                'status' => $exception->getStatus(),
-                'code'   => $exception->getErrorCode(),
-                'title'  => $exception->getTitle(),
-                'detail' => $exception->getDetail(),
+                'status' => (string)$exception->getStatus(),
+                'code'   => (string)$exception->getErrorCode(),
+                'title'  => (string)$exception->getTitle(),
+                'detail' => (string)$exception->getDetail(),
                 'source' => $exception->getSource(),
                 'meta'   => $exception->getMeta(),
             ]

--- a/tests/Transformers/ErrorTransformerTest.php
+++ b/tests/Transformers/ErrorTransformerTest.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace MyParcelCom\JsonApi\Tests\Transformers;
+
+use MyParcelCom\JsonApi\Exceptions\Interfaces\JsonSchemaErrorInterface;
+use MyParcelCom\JsonApi\Transformers\ErrorTransformer;
+use PHPUnit\Framework\TestCase;
+
+class ErrorTransformerTest extends TestCase
+{
+    /** @test */
+    public function testTransform()
+    {
+        $exception = \Mockery::mock(JsonSchemaErrorInterface::class, [
+            'getId'        => '123',
+            'getLinks'     => [
+                'api_specification' => 'The combined address fields exceed the limit of 35 characters.',
+            ],
+            'getStatus'    => 422,
+            'getErrorCode' => '456',
+            'getTitle'     => 'Value is too long',
+            'getDetail'    => 'The combined address fields exceed the limit of 35 characters.',
+            'getSource'    => [
+                'pointer' => '/data/attributes/recipient_address/street_1',
+            ],
+            'getMeta'      => [
+                'carrier_rules' => [
+                    [
+                        "type"  => "max-length",
+                        "value" => 35,
+                    ],
+                    [
+                        "type" => "required",
+                    ],
+                ],
+            ],
+        ]);
+
+        $transformedError = (new ErrorTransformer())->transform($exception);
+
+        $this->assertSame([
+            'id'     => '123',
+            'links'  => [
+                'api_specification' => 'The combined address fields exceed the limit of 35 characters.',
+            ],
+            'status' => '422',
+            'code'   => '456',
+            'title'  => 'Value is too long',
+            'detail' => 'The combined address fields exceed the limit of 35 characters.',
+            'source' => [
+                'pointer' => '/data/attributes/recipient_address/street_1',
+            ],
+            'meta'   => [
+                'carrier_rules' => [
+                    [
+                        "type"  => "max-length",
+                        "value" => 35,
+                    ],
+                    [
+                        "type" => "required",
+                    ],
+                ],
+            ],
+        ], $transformedError);
+    }
+}


### PR DESCRIPTION
The `status` attribute in an error response was an `integer` while according to the [json-api specification](https://jsonapi.org/format/#errors) it should be a `string`.

Also added a test to make sure exceptions are correctly transformed.