### PR TITLE
:arrow_down: reverted laravel dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "illuminate/support": "^5.0",
     "intouch/newrelic": "^1.0.3",
     "justinrainbow/json-schema": "^5.2",
-    "laravel/framework": "5.7.*"
+    "laravel/framework": "^5.4"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "47c25d450705c6c86975b82a62670633",
+    "content-hash": "05478cfce6daa901a9f41b8605eb233e",
     "packages": [
         {
             "name": "doctrine/inflector",


### PR DESCRIPTION
- Reverted laravel dependency because this package can still be used in 5.4 projects.