### PR TITLE
MP-2642 ⚡️ Optimize including of resources

### DIFF
--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -260,7 +260,6 @@ class ExceptionHandler extends Handler
      * Report or log an exception.
      *
      * @param Exception $e
-     * @return void
      */
     public function report(Exception $e): void
     {

--- a/src/Resources/ResourceIdentifier.php
+++ b/src/Resources/ResourceIdentifier.php
@@ -14,14 +14,19 @@ class ResourceIdentifier implements JsonSerializable
     /** @var string */
     private $type;
 
+    /** @var string */
+    private $parentId;
+
     /**
-     * @param string $id
-     * @param string $type
+     * @param string      $id
+     * @param string      $type
+     * @param string|null $parentId
      */
-    public function __construct(string $id, string $type)
+    public function __construct(string $id, string $type, string $parentId = null)
     {
         $this->id = $id;
         $this->type = $type;
+        $this->parentId = $parentId;
     }
 
     /**
@@ -38,6 +43,14 @@ class ResourceIdentifier implements JsonSerializable
     public function getType(): string
     {
         return $this->type;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getParentId(): ?string
+    {
+        return $this->parentId;
     }
 
     /**

--- a/src/Transformers/AbstractTransformer.php
+++ b/src/Transformers/AbstractTransformer.php
@@ -126,14 +126,15 @@ abstract class AbstractTransformer implements TransformerInterface
     }
 
     /**
-     * @param string $id
-     * @param string $type
-     * @param string $class
+     * @param string      $id
+     * @param string      $type
+     * @param string      $class
+     * @param string|null $parentId
      * @return array
      */
-    protected function transformRelationshipForIdentifier(string $id, string $type, string $class): array
+    protected function transformRelationshipForIdentifier(string $id, string $type, string $class, string $parentId = null): array
     {
-        $resource = new ResourceIdentifier($id, $type);
+        $resource = new ResourceIdentifier($id, $type, $parentId);
         $transformer = $this->transformerFactory->createFromModel($class);
         $relationship = ['data' => $resource->jsonSerialize()];
 

--- a/src/Transformers/TransformerCollection.php
+++ b/src/Transformers/TransformerCollection.php
@@ -8,8 +8,13 @@ use Illuminate\Support\Collection;
 
 class TransformerCollection
 {
+    /** @var Collection */
     protected $collection;
+
+    /** @var TransformerFactory */
     protected $transformerFactory;
+
+    /** @var Collection */
     private $transformerItems;
 
     /**
@@ -43,14 +48,15 @@ class TransformerCollection
      *
      * @param array $relationships   the relationships that we want to include
      * @param array $alreadyIncluded the already included items
+     * @param array $resourceData    resource data containing relationships (to comply with TransformerItem getIncluded)
      * @return array
      */
-    public function getIncluded(array $relationships = [], array $alreadyIncluded = []): array
+    public function getIncluded(array $relationships = [], array $alreadyIncluded = [], array $resourceData = []): array
     {
         $included = [];
 
         foreach ($this->getTransformerItems() as $item) {
-            $included = array_merge($included, $item->getIncluded($relationships, $alreadyIncluded));
+            $included = array_merge($included, $item->getIncluded($relationships, array_merge($included, $alreadyIncluded), $item->getData()));
         }
 
         return $included;

--- a/src/Transformers/TransformerResource.php
+++ b/src/Transformers/TransformerResource.php
@@ -96,11 +96,10 @@ class TransformerResource
     public function getData(): array
     {
         $this->prepareData();
-        if ($this->multipleResult) {
-            return $this->toArrayMultiple();
-        } else {
-            return $this->toArraySingle();
-        }
+
+        return ($this->multipleResult)
+            ? $this->toArrayMultiple()
+            : $this->toArraySingle();
     }
 
     /**
@@ -153,14 +152,12 @@ class TransformerResource
         return $res;
     }
 
-    /**
-     * @return void
-     */
     public function prepareData(): void
     {
         foreach ($this->resources as $resource) {
-            $this->data = array_merge($this->data, $resource->getData());
-            $this->includes = array_merge($this->includes, $resource->getIncluded($this->requestedIncludes, $this->includes));
+            $resourceData = $resource->getData();
+            $this->data = array_merge($this->data, $resourceData);
+            $this->includes = array_merge($this->includes, $resource->getIncluded($this->requestedIncludes, $this->includes, $resourceData));
         }
 
         $this->includes = array_unique($this->includes, SORT_REGULAR); // remove duplicates

--- a/tests/Stubs/TransformerStub.php
+++ b/tests/Stubs/TransformerStub.php
@@ -111,9 +111,9 @@ class TransformerStub extends AbstractTransformer
         return parent::getTimestamp($dateTime);
     }
 
-    public function transformRelationshipForIdentifier(string $id, string $type, string $class): array
+    public function transformRelationshipForIdentifier(string $id, string $type, string $class, string $parentId = null): array
     {
-        return parent::transformRelationshipForIdentifier($id, $type, $class);
+        return parent::transformRelationshipForIdentifier($id, $type, $class, $parentId);
     }
 
     public function transformRelationshipForIdentifiers(array $ids, string $type, array $links = null): array

--- a/tests/Transformers/TransformerServiceTest.php
+++ b/tests/Transformers/TransformerServiceTest.php
@@ -6,7 +6,6 @@ namespace MyParcelCom\JsonApi\Tests\Transformers;
 
 use Illuminate\Support\Collection;
 use Mockery;
-use MyParcelCom\JsonApi\Http\Interfaces\RequestInterface;
 use MyParcelCom\JsonApi\Http\Paginator;
 use MyParcelCom\JsonApi\Resources\Interfaces\ResourcesInterface;
 use MyParcelCom\JsonApi\Tests\Mocks\Resources\FatherMock;
@@ -47,8 +46,8 @@ class TransformerServiceTest extends TestCase
         $this->transformerService = new TransformerService($transformerFactory);
         $this->transformerService->setPaginator($paginator);
         $this->transformerService->setIncludes([
-            'mother',
-            'father',
+            0        => 'mother',
+            1        => 'father',
             'father' => [
                 'father' => [
                     'father',


### PR DESCRIPTION
https://myparcelcombv.atlassian.net/browse/MP-2642
- Added filtering of the required `includes` to avoid duplicate database queries.
- Added `parentId` to `ResourceIdentifier` to transform links with multiple ID's.

The `getFilteredIncludes()` is actually revived from PR https://github.com/MyParcelCOM/json-api/pull/31 where it was deleted.