### PR TITLE
🚑 Silence non-5xx errors in Rollbar

### DIFF
--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -297,7 +297,9 @@ class ExceptionHandler extends Handler
             }, $e->getErrors());
         }
 
-        $this->logger->error($e->getMessage(), $context);
+        $e->getStatus() >= 500
+            ? $this->logger->error($e->getMessage(), $context)
+            : $this->logger->warning($e->getMessage(), $context);
     }
 
     /**

--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -33,6 +33,7 @@ use MyParcelCom\JsonApi\Exceptions\TooManyRequestsException;
 use MyParcelCom\JsonApi\Exceptions\UnprocessableEntityException;
 use MyParcelCom\JsonApi\Transformers\ErrorTransformer;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Exception\RequestExceptionInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Throwable;
@@ -297,9 +298,18 @@ class ExceptionHandler extends Handler
             }, $e->getErrors());
         }
 
-        $e->getStatus() >= 500
-            ? $this->logger->error($e->getMessage(), $context)
-            : $this->logger->warning($e->getMessage(), $context);
+        $this->isWarning($e)
+            ? $this->logger->warning($e->getMessage(), $context)
+            : $this->logger->error($e->getMessage(), $context);
+    }
+
+    private function isWarning(Exception $exception): bool
+    {
+        // Not all exceptions have the getStatus method.
+        // We define it in the JsonSchemaErrorInterface, which all the exceptions that we throw implement.
+        return $exception instanceof JsonSchemaErrorInterface
+            && $exception->getStatus() !== null
+            && $exception->getStatus() < 500;
     }
 
     /**


### PR DESCRIPTION
# Related issues
- https://myparcelcombv.atlassian.net/browse/MP-3339

# Notes
We cannot blindly assume that every thrown exception has a status code related to it, since not all Exceptions are request exceptions. All (or most..?) of the Exceptions defined in this package implement the JsonSchemaErrorInterface, which includes the getStatus() method. In the API however, we also throw the Guzzle/RequestException. This method doesn't have the getStatus() method, and so we will have to make some additional changes in our API code to make sure this isn't logged.