### PR TITLE
♿️ Deep filter request filters

### DIFF
--- a/src/Http/Traits/RequestTrait.php
+++ b/src/Http/Traits/RequestTrait.php
@@ -84,6 +84,21 @@ trait RequestTrait
      */
     public function getFilter(): array
     {
-        return array_filter($this->query('filter', []));
+        return $this->arrayDeepFilter($this->query('filter', []));
+    }
+
+    /**
+     * @param array $array
+     * @return array
+     */
+    private function arrayDeepFilter(array $array): array
+    {
+        foreach ($array as $key => $value) {
+            if (is_array($value)) {
+                $array[$key] = $this->arrayDeepFilter($value);
+            }
+        }
+
+        return array_filter($array);
     }
 }

--- a/tests/Http/Traits/RequestTraitTest.php
+++ b/tests/Http/Traits/RequestTraitTest.php
@@ -82,6 +82,9 @@ class RequestTraitTest extends TestCase
         $this->assertEquals(
             [
                 'foo' => 'bar',
+                'yes' => [
+                    'some' => 'thing',
+                ],
             ],
             $request->getFilter()
         );
@@ -105,6 +108,12 @@ class RequestTraitTest extends TestCase
                 'filter'  => [
                     'foo' => 'bar',
                     'baz' => '',
+                    'yes' => [
+                        'some' => 'thing',
+                    ],
+                    'no'  => [
+                        'thing' => '',
+                    ],
                 ],
             ];
 


### PR DESCRIPTION
`filter[sender_address][country_code]=` resulted in 0 records, because the column was filtered on an empty string.