### PR TITLE
🔊 Expanded context on error reporting

### DIFF
--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MyParcelCom\JsonApi;
 
-use Exception;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Foundation\Exceptions\Handler;
 use Illuminate\Foundation\Http\Exceptions\MaintenanceModeException;
@@ -284,7 +283,11 @@ class ExceptionHandler extends Handler
             return;
         }
 
-        $context = ['trace' => array_slice($e->getTrace(), 0, 5)];
+        $context = [
+            'trace' => array_slice($e->getTrace(), 0, 5),
+            'file'  => $e->getFile(),
+            'line'  => $e->getLine(),
+        ];
 
         if ($e instanceof MultiErrorInterface) {
             $context['multi_error_errors'] = array_map(function (JsonSchemaErrorInterface $error) {
@@ -297,9 +300,11 @@ class ExceptionHandler extends Handler
             }, $e->getErrors());
         }
 
+        $message = "{$e->getMessage()}, called in {$e->getFile()} on line {$e->getLine()}";
+
         $this->isWarning($e)
-            ? $this->logger->warning($e->getMessage(), $context)
-            : $this->logger->error($e->getMessage(), $context);
+            ? $this->logger->warning($message, $context)
+            : $this->logger->error($message, $context);
     }
 
     private function isWarning(Throwable $exception): bool

--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -300,11 +300,9 @@ class ExceptionHandler extends Handler
             }, $e->getErrors());
         }
 
-        $message = "{$e->getMessage()}, called in {$e->getFile()} on line {$e->getLine()}";
-
         $this->isWarning($e)
-            ? $this->logger->warning($message, $context)
-            : $this->logger->error($message, $context);
+            ? $this->logger->warning($e->getMessage(), $context)
+            : $this->logger->error($e->getMessage(), $context);
     }
 
     private function isWarning(Throwable $exception): bool

--- a/tests/ExceptionHandlerTest.php
+++ b/tests/ExceptionHandlerTest.php
@@ -177,7 +177,7 @@ class ExceptionHandlerTest extends TestCase
      */
     public function testReport()
     {
-        $message = 'an error occured';
+        $message = 'an error occurred';
         $exception = new Exception($message);
         $trace = array_slice($exception->getTrace(), 0, 5);
 
@@ -188,12 +188,20 @@ class ExceptionHandlerTest extends TestCase
         }
 
         $logger = Mockery::mock(LoggerInterface::class);
-        $logger->shouldReceive('error')->withArgs([$message, ['trace' => $trace]]);
+        $logger->shouldReceive('error')->withArgs([
+            "an error occurred, called in {$exception->getFile()} on line {$exception->getLine()}",
+            [
+                'trace' => $trace,
+                'file'  => $exception->getFile(),
+                'line'  => $exception->getLine(),
+            ],
+        ]);
 
         try {
             $this->handler->setLogger($logger);
             $this->handler->report($exception);
         } catch (Throwable $e) {
+            dd($e->getMessage());
             $this->fail('An exception was thrown when report was called with a logger');
         }
 
@@ -215,8 +223,13 @@ class ExceptionHandlerTest extends TestCase
 
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldReceive('warning')->withArgs([
-            'There was a problem with the request to the carrier. The original response can be found in the meta under `carrier_response`.',
-            ['trace' => $trace],
+            "There was a problem with the request to the carrier. The original response can be found in the meta under `carrier_response`." .
+            ", called in {$exception->getFile()} on line {$exception->getLine()}",
+            [
+                'trace' => $trace,
+                'file'  => $exception->getFile(),
+                'line'  => $exception->getLine(),
+            ],
         ]);
 
         try {

--- a/tests/ExceptionHandlerTest.php
+++ b/tests/ExceptionHandlerTest.php
@@ -189,7 +189,7 @@ class ExceptionHandlerTest extends TestCase
 
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldReceive('error')->withArgs([
-            "an error occurred, called in {$exception->getFile()} on line {$exception->getLine()}",
+            "an error occurred",
             [
                 'trace' => $trace,
                 'file'  => $exception->getFile(),
@@ -201,7 +201,6 @@ class ExceptionHandlerTest extends TestCase
             $this->handler->setLogger($logger);
             $this->handler->report($exception);
         } catch (Throwable $e) {
-            dd($e->getMessage());
             $this->fail('An exception was thrown when report was called with a logger');
         }
 
@@ -223,8 +222,7 @@ class ExceptionHandlerTest extends TestCase
 
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldReceive('warning')->withArgs([
-            "There was a problem with the request to the carrier. The original response can be found in the meta under `carrier_response`." .
-            ", called in {$exception->getFile()} on line {$exception->getLine()}",
+            "There was a problem with the request to the carrier. The original response can be found in the meta under `carrier_response`.",
             [
                 'trace' => $trace,
                 'file'  => $exception->getFile(),


### PR DESCRIPTION
Sometimes simple exceptions don't really have a stack trace (like PHP type errors): https://rollbar.com/myparcelcom/microservice-dhl-de/items/11/

This is because PHP code is loaded, not executed yet and PHP cannot make sense of something (like a strict return type and void returned). In these cases the exception has a file and line of code. This information is missing in our reporting.

Json-api package should be updated to include this information always.

# Changes 
- Added exception file and line when reporting
- Fixed tests

# IMPORTANT
We should still discuss this solution, I added something from myself. My suggestion (see in code) is to include the file path and line where the exception occurred. This will be handy for many cases. However, it might also be annoying. Example would be: 

> There was a problem with the request to the carrier. The original response can be found in the meta under carrier_response.

Becomes:

> There was a problem with the request to the carrier. The original response can be found in the meta under carrier_response., called in /opt/app/bla/bla/bla.php on line 123

Lets discuss!

# Jira
https://myparcelcombv.atlassian.net/browse/MP-3996