### PR TITLE
🚑️ RequestInterface fullUrl needs to fit Illuminate\Http\Request

### DIFF
--- a/src/Http/Interfaces/RequestInterface.php
+++ b/src/Http/Interfaces/RequestInterface.php
@@ -50,5 +50,5 @@ interface RequestInterface
      *
      * @return string
      */
-    public function fullUrl(): string;
+    public function fullUrl();
 }


### PR DESCRIPTION
Fix: Declaration of `Illuminate\Http\Request::fullUrl()` must be compatible with
`MyParcelCom\JsonApi\Http\Interfaces\RequestInterface::fullUrl(): string`