### PR TITLE
🪆 Make arrayDeepFilter() available through a trait

### DIFF
--- a/src/Http/Traits/RequestTrait.php
+++ b/src/Http/Traits/RequestTrait.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace MyParcelCom\JsonApi\Http\Traits;
 
 use MyParcelCom\JsonApi\Http\Paginator;
+use MyParcelCom\JsonApi\Traits\ArrayFilterTrait;
 
 trait RequestTrait
 {
+    use ArrayFilterTrait;
+
     /**
      * Get the pagination from the current url.
      *
@@ -85,20 +88,5 @@ trait RequestTrait
     public function getFilter(): array
     {
         return $this->arrayDeepFilter($this->query('filter', []));
-    }
-
-    /**
-     * @param array $array
-     * @return array
-     */
-    private function arrayDeepFilter(array $array): array
-    {
-        foreach ($array as $key => $value) {
-            if (is_array($value)) {
-                $array[$key] = $this->arrayDeepFilter($value);
-            }
-        }
-
-        return array_filter($array);
     }
 }

--- a/src/Traits/ArrayFilterTrait.php
+++ b/src/Traits/ArrayFilterTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\JsonApi\Traits;
+
+trait ArrayFilterTrait
+{
+    /**
+     * Do a deep filter on an array to remove:
+     * - null values
+     * - empty strings
+     * - leftover empty arrays
+     */
+    private function arrayDeepFilter(array $array): array
+    {
+        $array = array_filter($array, fn ($var) => $var !== null && $var !== '');
+
+        foreach ($array as $key => $value) {
+            if (is_array($value)) {
+                $array[$key] = $this->arrayDeepFilter($value);
+
+                if (count($array[$key]) < 1) {
+                    unset($array[$key]);
+                }
+            }
+        }
+
+        return $array;
+    }
+}

--- a/src/Transformers/AbstractTransformer.php
+++ b/src/Transformers/AbstractTransformer.php
@@ -7,10 +7,13 @@ namespace MyParcelCom\JsonApi\Transformers;
 use DateTime;
 use Illuminate\Contracts\Routing\UrlGenerator;
 use MyParcelCom\JsonApi\Resources\ResourceIdentifier;
+use MyParcelCom\JsonApi\Traits\ArrayFilterTrait;
 
 /** @template TModel */
 abstract class AbstractTransformer implements TransformerInterface
 {
+    use ArrayFilterTrait;
+
     /** @var UrlGenerator */
     protected $urlGenerator;
 
@@ -52,29 +55,6 @@ abstract class AbstractTransformer implements TransformerInterface
             'links'         => $this->getLinks($model),
             'relationships' => $this->getRelationships($model),
         ]);
-    }
-
-    /**
-     * Do a deep filter on an array to remove all null values
-     *
-     * @param array $array
-     * @return array
-     */
-    private function arrayDeepFilter(array $array): array
-    {
-        $array = array_filter($array, function ($var) {
-            return ($var !== null);
-        });
-        foreach ($array as $key => $subPart) {
-            if (is_array($subPart)) {
-                $array[$key] = $this->arrayDeepFilter($subPart);
-                if (count($array[$key]) < 1) {
-                    unset($array[$key]);
-                }
-            }
-        }
-
-        return $array;
     }
 
     /**


### PR DESCRIPTION
This PR is opened because I want to use the `arrayDeepFilter()` functionality outside of this class.

It also seems that this repository already had 2 separate `arrayDeepFilter()` functions which did practically the same thing.
The small differences: the request one also filtered empty strings, while the transformer one removed leftover empty arrays.

Both use cases actually benefit from each others functionality, so our new `arrayDeepFilter()` trait does both!