### PR TITLE
🐛 Allow transformed model id to be null

### DIFF
--- a/src/Transformers/AbstractTransformer.php
+++ b/src/Transformers/AbstractTransformer.php
@@ -202,7 +202,7 @@ abstract class AbstractTransformer implements TransformerInterface
     /**
      * @param TModel $model
      */
-    public function getId($model): string|int
+    public function getId($model): string|int|null
     {
         return $model->getId();
     }

--- a/src/Transformers/TransformerInterface.php
+++ b/src/Transformers/TransformerInterface.php
@@ -28,5 +28,5 @@ interface TransformerInterface
 
     public function getMeta($model): array;
 
-    public function getId($model): string|int;
+    public function getId($model): string|int|null;
 }

--- a/tests/Stubs/TransformerStub.php
+++ b/tests/Stubs/TransformerStub.php
@@ -25,17 +25,11 @@ class TransformerStub extends AbstractTransformer
         return $this;
     }
 
-    /**
-     * @param mixed $model
-     */
     public function getId($model): string
     {
         return 'mockId';
     }
 
-    /**
-     * @param object $model
-     */
     public function validateModel($model): void
     {
     }
@@ -45,9 +39,6 @@ class TransformerStub extends AbstractTransformer
         return $this->urlGenerator;
     }
 
-    /**
-     * @param mixed $dependency
-     */
     public function setDependency($dependency): self
     {
         $this->dependency = $dependency;
@@ -55,9 +46,6 @@ class TransformerStub extends AbstractTransformer
         return $this;
     }
 
-    /**
-     * @return mixed
-     */
     public function getDependency()
     {
         return $this->dependency;


### PR DESCRIPTION
Transforming models that have not yet been persisted should also be possible.