### PR TITLE
♻️ Scope slugs can be enums

### DIFF
--- a/src/Exceptions/InvalidScopeException.php
+++ b/src/Exceptions/InvalidScopeException.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace MyParcelCom\JsonApi\Exceptions;
 
+use BackedEnum;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
+use UnitEnum;
 
 /**
  * This exception is thrown when a scope is either not available at all, not unavailable for the chosen grant type or
@@ -13,10 +15,18 @@ use Throwable;
  */
 class InvalidScopeException extends AbstractException
 {
-    public function __construct(array $slugs, Throwable $previous = null)
+    public function __construct(array $scopeSlugs, Throwable $previous = null)
     {
+        $scopeStrings = collect($scopeSlugs)
+            ->map(fn ($scope) => match (true) {
+                $scope instanceof BackedEnum => $scope->value,
+                $scope instanceof UnitEnum   => $scope->name,
+                default                      => $scope,
+            })
+            ->toArray();
+
         parent::__construct(
-            'The following scopes are not available to the requesting client: ' . implode(', ', $slugs),
+            'The following scopes are not available to the requesting client: ' . implode(', ', $scopeStrings),
             self::AUTH_INVALID_SCOPE,
             Response::HTTP_FORBIDDEN,
             $previous,

--- a/src/Exceptions/MissingScopeException.php
+++ b/src/Exceptions/MissingScopeException.php
@@ -4,15 +4,25 @@ declare(strict_types=1);
 
 namespace MyParcelCom\JsonApi\Exceptions;
 
+use BackedEnum;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
+use UnitEnum;
 
 class MissingScopeException extends AbstractException
 {
-    public function __construct(array $scopes, Throwable $previous = null)
+    public function __construct(array $scopeSlugs, Throwable $previous = null)
     {
+        $scopeStrings = collect($scopeSlugs)
+            ->map(fn ($scope) => match (true) {
+                $scope instanceof BackedEnum => $scope->value,
+                $scope instanceof UnitEnum   => $scope->name,
+                default                      => $scope,
+            })
+            ->toArray();
+
         parent::__construct(
-            'The used access token does not contain the required scope(s): ' . implode(', ', $scopes) . '.',
+            'The used access token does not contain the required scope(s): ' . implode(', ', $scopeStrings) . '.',
             self::AUTH_MISSING_SCOPE,
             Response::HTTP_FORBIDDEN,
             $previous,


### PR DESCRIPTION
Make the scope exceptions support enums and strings.