### PR TITLE
✨ Support enums

### DIFF
--- a/src/Enums/NullResource.php
+++ b/src/Enums/NullResource.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\JsonApi\Enums;
+
+enum NullResource: string
+{
+    case TYPE = '';
+}

--- a/src/Exceptions/InvalidScopeException.php
+++ b/src/Exceptions/InvalidScopeException.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace MyParcelCom\JsonApi\Exceptions;
 
-use BackedEnum;
+use MyParcelCom\JsonApi\Traits\EnumTrait;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
-use UnitEnum;
 
 /**
  * This exception is thrown when a scope is either not available at all, not unavailable for the chosen grant type or
@@ -15,14 +14,12 @@ use UnitEnum;
  */
 class InvalidScopeException extends AbstractException
 {
+    use EnumTrait;
+
     public function __construct(array $scopeSlugs, Throwable $previous = null)
     {
         $scopeStrings = collect($scopeSlugs)
-            ->map(fn ($scope) => match (true) {
-                $scope instanceof BackedEnum => $scope->value,
-                $scope instanceof UnitEnum   => $scope->name,
-                default                      => $scope,
-            })
+            ->map(fn (mixed $scopeSlug) => $this->getEnumValue($scopeSlug))
             ->toArray();
 
         parent::__construct(

--- a/src/Exceptions/MissingScopeException.php
+++ b/src/Exceptions/MissingScopeException.php
@@ -4,21 +4,18 @@ declare(strict_types=1);
 
 namespace MyParcelCom\JsonApi\Exceptions;
 
-use BackedEnum;
+use MyParcelCom\JsonApi\Traits\EnumTrait;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
-use UnitEnum;
 
 class MissingScopeException extends AbstractException
 {
+    use EnumTrait;
+
     public function __construct(array $scopeSlugs, Throwable $previous = null)
     {
         $scopeStrings = collect($scopeSlugs)
-            ->map(fn ($scope) => match (true) {
-                $scope instanceof BackedEnum => $scope->value,
-                $scope instanceof UnitEnum   => $scope->name,
-                default                      => $scope,
-            })
+            ->map(fn (mixed $scopeSlug) => $this->getEnumValue($scopeSlug))
             ->toArray();
 
         parent::__construct(

--- a/src/Exceptions/RelationshipCannotBeModifiedException.php
+++ b/src/Exceptions/RelationshipCannotBeModifiedException.php
@@ -4,15 +4,22 @@ declare(strict_types=1);
 
 namespace MyParcelCom\JsonApi\Exceptions;
 
+use MyParcelCom\JsonApi\Traits\EnumTrait;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
+use UnitEnum;
 
 class RelationshipCannotBeModifiedException extends AbstractException
 {
-    public function __construct(string $relationshipType, Throwable $previous = null)
+    use EnumTrait;
+
+    public function __construct(UnitEnum|string $relationshipType, Throwable $previous = null)
     {
         parent::__construct(
-            "The relationship of type '{$relationshipType}' cannot be modified on this resource.",
+            sprintf(
+                "The relationship of type '%s' cannot be modified on this resource.",
+                $this->getEnumValue($relationshipType),
+            ),
             self::RELATIONSHIP_CANNOT_BE_MODIFIED,
             Response::HTTP_FORBIDDEN,
             $previous,

--- a/src/Exceptions/ResourceHandledBy3rdPartyException.php
+++ b/src/Exceptions/ResourceHandledBy3rdPartyException.php
@@ -4,17 +4,19 @@ declare(strict_types=1);
 
 namespace MyParcelCom\JsonApi\Exceptions;
 
+use MyParcelCom\JsonApi\Traits\EnumTrait;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
+use UnitEnum;
 
 class ResourceHandledBy3rdPartyException extends AbstractException
 {
-    public function __construct(string $resourceType, string $platform, Throwable $previous = null)
-    {
-        $message = sprintf('One or more of the %s resource is handled by a 3rd party.', $resourceType);
+    use EnumTrait;
 
+    public function __construct(UnitEnum|string $resourceType, string $platform, Throwable $previous = null)
+    {
         parent::__construct(
-            $message,
+            sprintf('One or more of the %s resource is handled by a 3rd party.', $this->getEnumValue($resourceType)),
             self::RESOURCE_HANDLED_BY_3RD_PARTY,
             Response::HTTP_CONFLICT,
             $previous,

--- a/src/Exceptions/ResourceNotFoundException.php
+++ b/src/Exceptions/ResourceNotFoundException.php
@@ -4,17 +4,19 @@ declare(strict_types=1);
 
 namespace MyParcelCom\JsonApi\Exceptions;
 
+use MyParcelCom\JsonApi\Traits\EnumTrait;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
+use UnitEnum;
 
 class ResourceNotFoundException extends AbstractException
 {
-    public function __construct(string $resourceType, Throwable $previous = null)
-    {
-        $message = sprintf('One or more of the %s resource could not be found.', $resourceType);
+    use EnumTrait;
 
+    public function __construct(UnitEnum|string $resourceType, Throwable $previous = null)
+    {
         parent::__construct(
-            $message,
+            sprintf('One or more of the %s resource could not be found.', $this->getEnumValue($resourceType)),
             self::RESOURCE_NOT_FOUND,
             Response::HTTP_NOT_FOUND,
             $previous,

--- a/src/Traits/EnumTrait.php
+++ b/src/Traits/EnumTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\JsonApi\Traits;
+
+use BackedEnum;
+use UnitEnum;
+
+trait EnumTrait
+{
+    public function getEnumValue(mixed $enum): mixed
+    {
+        return match (true) {
+            $enum instanceof BackedEnum => $enum->value,
+            $enum instanceof UnitEnum   => $enum->name,
+            default                     => $enum,
+        };
+    }
+}

--- a/src/Transformers/AbstractTransformer.php
+++ b/src/Transformers/AbstractTransformer.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace MyParcelCom\JsonApi\Transformers;
 
+use BackedEnum;
 use DateTime;
 use Illuminate\Contracts\Routing\UrlGenerator;
+use MyParcelCom\JsonApi\Enums\NullResource;
 use MyParcelCom\JsonApi\Resources\ResourceIdentifier;
 use MyParcelCom\JsonApi\Traits\ArrayFilterTrait;
+use UnitEnum;
 
 /** @template TModel */
 abstract class AbstractTransformer implements TransformerInterface
@@ -17,6 +20,7 @@ abstract class AbstractTransformer implements TransformerInterface
     protected UrlGenerator $urlGenerator;
 
     protected string $type = '';
+    protected UnitEnum $resourceType = NullResource::TYPE;
 
     public function __construct(
         protected TransformerFactory $transformerFactory,
@@ -132,11 +136,17 @@ abstract class AbstractTransformer implements TransformerInterface
      */
     public function getType(): string
     {
-        if (empty($this->type)) {
-            throw new TransformerException('Error no transformer resource `type` set for model');
+        $type = match (true) {
+            !empty($this->type)                       => $this->type,
+            $this->resourceType instanceof BackedEnum => $this->resourceType->value,
+            $this->resourceType instanceof UnitEnum   => $this->resourceType->name,
+        };
+
+        if (empty($type)) {
+            throw new TransformerException('Error no `resourceType` or `type` set on transformer');
         }
 
-        return $this->type;
+        return $type;
     }
 
     /**

--- a/src/Transformers/AbstractTransformer.php
+++ b/src/Transformers/AbstractTransformer.php
@@ -4,18 +4,19 @@ declare(strict_types=1);
 
 namespace MyParcelCom\JsonApi\Transformers;
 
-use BackedEnum;
 use DateTime;
 use Illuminate\Contracts\Routing\UrlGenerator;
 use MyParcelCom\JsonApi\Enums\NullResource;
 use MyParcelCom\JsonApi\Resources\ResourceIdentifier;
 use MyParcelCom\JsonApi\Traits\ArrayFilterTrait;
+use MyParcelCom\JsonApi\Traits\EnumTrait;
 use UnitEnum;
 
 /** @template TModel */
 abstract class AbstractTransformer implements TransformerInterface
 {
     use ArrayFilterTrait;
+    use EnumTrait;
 
     protected UrlGenerator $urlGenerator;
 
@@ -136,11 +137,7 @@ abstract class AbstractTransformer implements TransformerInterface
      */
     public function getType(): string
     {
-        $type = match (true) {
-            !empty($this->type)                       => $this->type,
-            $this->resourceType instanceof BackedEnum => $this->resourceType->value,
-            $this->resourceType instanceof UnitEnum   => $this->resourceType->name,
-        };
+        $type = empty($this->type) ? $this->getEnumValue($this->resourceType) : $this->type;
 
         if (empty($type)) {
             throw new TransformerException('Error no `resourceType` or `type` set on transformer');

--- a/tests/Enums/TestBackedEnum.php
+++ b/tests/Enums/TestBackedEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\JsonApi\Tests\Enums;
+
+enum TestBackedEnum: string
+{
+    case TEST = 'test';
+}

--- a/tests/Enums/TestUnitEnum.php
+++ b/tests/Enums/TestUnitEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelCom\JsonApi\Tests\Enums;
+
+enum TestUnitEnum
+{
+    case test;
+}

--- a/tests/Exceptions/ExceptionsTest.php
+++ b/tests/Exceptions/ExceptionsTest.php
@@ -35,6 +35,7 @@ use MyParcelCom\JsonApi\Exceptions\ResourceHandledBy3rdPartyException;
 use MyParcelCom\JsonApi\Exceptions\ResourceNotFoundException;
 use MyParcelCom\JsonApi\Exceptions\TooManyRequestsException;
 use MyParcelCom\JsonApi\Exceptions\UnprocessableEntityException;
+use MyParcelCom\JsonApi\Tests\Enums\TestBackedEnum;
 use PHPUnit\Framework\TestCase;
 
 class ExceptionsTest extends TestCase
@@ -210,6 +211,13 @@ class ExceptionsTest extends TestCase
         $this->assertEquals('One or more of the API resource could not be found.', $exception->getMessage());
     }
 
+    public function testResourceNotFoundExceptionUsingEnum(): void
+    {
+        $exception = new ResourceNotFoundException(TestBackedEnum::TEST);
+
+        $this->assertEquals('One or more of the test resource could not be found.', $exception->getMessage());
+    }
+
     public function testUnprocessableEntityException(): void
     {
         $exception = new UnprocessableEntityException('RAW', new Exception('G-Star'));
@@ -279,6 +287,16 @@ class ExceptionsTest extends TestCase
         );
     }
 
+    public function testRelationshipCannotBeModifiedExceptionUsingEnum(): void
+    {
+        $exception = new RelationshipCannotBeModifiedException(TestBackedEnum::TEST);
+
+        $this->assertEquals(
+            "The relationship of type 'test' cannot be modified on this resource.",
+            $exception->getMessage(),
+        );
+    }
+
     public function testInvalidCredentialsException(): void
     {
         $errors = [
@@ -320,5 +338,12 @@ class ExceptionsTest extends TestCase
         self::assertEquals('10014', $exception->getCode());
         self::assertEquals(409, $exception->getStatus());
         self::assertEquals(['3rd_party' => 'Bol'], $exception->getMeta());
+    }
+
+    public function testResourceHandledBy3rdPartyExceptionUsingEnum(): void
+    {
+        $exception = new ResourceHandledBy3rdPartyException(TestBackedEnum::TEST, 'Bol');
+
+        $this->assertEquals('One or more of the test resource is handled by a 3rd party.', $exception->getMessage());
     }
 }

--- a/tests/Stubs/TransformerStub.php
+++ b/tests/Stubs/TransformerStub.php
@@ -15,16 +15,6 @@ class TransformerStub extends AbstractTransformer
 
     protected string $type = 'test';
 
-    /**
-     * Helper function to reset the type for the abstract exception test.
-     */
-    public function clearType(): self
-    {
-        $this->type = '';
-
-        return $this;
-    }
-
     public function getId($model): string
     {
         return 'mockId';

--- a/tests/Transformers/AbstractTransformerTest.php
+++ b/tests/Transformers/AbstractTransformerTest.php
@@ -14,6 +14,17 @@ use MyParcelCom\JsonApi\Transformers\TransformerException;
 use MyParcelCom\JsonApi\Transformers\TransformerFactory;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use UnitEnum;
+
+enum TestUnitEnum
+{
+    case test;
+}
+
+enum TestBackedEnum: string
+{
+    case TYPE = 'test';
+}
 
 class AbstractTransformerTest extends TestCase
 {
@@ -64,10 +75,49 @@ class AbstractTransformerTest extends TestCase
         $this->assertEmpty($this->transformer->getRelationLink($this->model));
     }
 
+    public function testTypeUsingUnitEnum(): void
+    {
+        $transformer = new class extends TransformerStub {
+            protected string $type = '';
+            protected UnitEnum $resourceType = TestUnitEnum::test;
+
+            public function __construct()
+            {
+                parent::__construct(Mockery::mock(TransformerFactory::class));
+            }
+        };
+
+        $this->assertSame('test', $transformer->getType());
+    }
+
+    public function testTypeUsingBackedEnum(): void
+    {
+        $transformer = new class extends TransformerStub {
+            protected string $type = '';
+            protected UnitEnum $resourceType = TestBackedEnum::TYPE;
+
+            public function __construct()
+            {
+                parent::__construct(Mockery::mock(TransformerFactory::class));
+            }
+        };
+
+        $this->assertSame('test', $transformer->getType());
+    }
+
     public function testGetTypeException(): void
     {
+        $transformer = new class extends TransformerStub {
+            protected string $type = '';
+
+            public function __construct()
+            {
+                parent::__construct(Mockery::mock(TransformerFactory::class));
+            }
+        };
+
         $this->expectException(TransformerException::class);
-        $this->transformer->clearType()->getType();
+        $transformer->getType();
     }
 
     public function testTransformRelationship(): void

--- a/tests/Transformers/AbstractTransformerTest.php
+++ b/tests/Transformers/AbstractTransformerTest.php
@@ -9,22 +9,14 @@ use Illuminate\Database\Eloquent\Model;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use MyParcelCom\JsonApi\Resources\ResourceIdentifier;
+use MyParcelCom\JsonApi\Tests\Enums\TestBackedEnum;
+use MyParcelCom\JsonApi\Tests\Enums\TestUnitEnum;
 use MyParcelCom\JsonApi\Tests\Stubs\TransformerStub;
 use MyParcelCom\JsonApi\Transformers\TransformerException;
 use MyParcelCom\JsonApi\Transformers\TransformerFactory;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use UnitEnum;
-
-enum TestUnitEnum
-{
-    case test;
-}
-
-enum TestBackedEnum: string
-{
-    case TYPE = 'test';
-}
 
 class AbstractTransformerTest extends TestCase
 {
@@ -94,7 +86,7 @@ class AbstractTransformerTest extends TestCase
     {
         $transformer = new class extends TransformerStub {
             protected string $type = '';
-            protected UnitEnum $resourceType = TestBackedEnum::TYPE;
+            protected UnitEnum $resourceType = TestBackedEnum::TEST;
 
             public function __construct()
             {


### PR DESCRIPTION
Added `enum` support for resource types in the following classes:

- `AbstractTransformer`
- `RelationshipCannotBeModifiedException`
- `ResourceHandledBy3rdPartyException`
- `ResourceNotFoundException`

For the transformer I decided to introduce a new `$resourceType` property next to the `string $type` to keep things backwards compatible. Also the `getType()` still returns a string, so all existing implementations will work as well.