### PR TITLE
♻️ Accept UnitEnum or string for resource functions

### DIFF
--- a/src/Resources/ResourceIdentifier.php
+++ b/src/Resources/ResourceIdentifier.php
@@ -5,12 +5,16 @@ declare(strict_types=1);
 namespace MyParcelCom\JsonApi\Resources;
 
 use JsonSerializable;
+use MyParcelCom\JsonApi\Traits\EnumTrait;
+use UnitEnum;
 
 class ResourceIdentifier implements JsonSerializable
 {
+    use EnumTrait;
+
     public function __construct(
         private string $id,
-        private string $type,
+        private UnitEnum|string $type,
         private ?string $parentId = null,
     ) {
     }
@@ -22,7 +26,7 @@ class ResourceIdentifier implements JsonSerializable
 
     public function getType(): string
     {
-        return $this->type;
+        return $this->getEnumValue($this->type);
     }
 
     public function getParentId(): ?string

--- a/src/Transformers/AbstractTransformer.php
+++ b/src/Transformers/AbstractTransformer.php
@@ -90,7 +90,7 @@ abstract class AbstractTransformer implements TransformerInterface
 
     protected function transformRelationshipForIdentifier(
         string $id,
-        string $type,
+        UnitEnum|string $type,
         string $class,
         string $parentId = null,
     ): array {
@@ -107,7 +107,7 @@ abstract class AbstractTransformer implements TransformerInterface
         return $relationship;
     }
 
-    protected function transformRelationshipForIdentifiers(array $ids, string $type, array $links = null): array
+    protected function transformRelationshipForIdentifiers(array $ids, UnitEnum|string $type, array $links = []): array
     {
         return array_filter([
             'data'  => array_map(fn ($id) => (new ResourceIdentifier($id, $type))->jsonSerialize(), $ids),

--- a/tests/Stubs/TransformerStub.php
+++ b/tests/Stubs/TransformerStub.php
@@ -8,6 +8,7 @@ use DateTime;
 use Illuminate\Contracts\Routing\UrlGenerator;
 use MyParcelCom\JsonApi\Resources\ResourceIdentifier;
 use MyParcelCom\JsonApi\Transformers\AbstractTransformer;
+use UnitEnum;
 
 class TransformerStub extends AbstractTransformer
 {
@@ -84,14 +85,14 @@ class TransformerStub extends AbstractTransformer
 
     public function transformRelationshipForIdentifier(
         string $id,
-        string $type,
+        UnitEnum|string $type,
         string $class,
         string $parentId = null,
     ): array {
         return parent::transformRelationshipForIdentifier($id, $type, $class, $parentId);
     }
 
-    public function transformRelationshipForIdentifiers(array $ids, string $type, array $links = null): array
+    public function transformRelationshipForIdentifiers(array $ids, UnitEnum|string $type, array $links = []): array
     {
         return parent::transformRelationshipForIdentifiers($ids, $type, $links);
     }


### PR DESCRIPTION
Since https://github.com/MyParcelCOM/json-api/pull/121 the type can be an enum or a string, but there are a few other functions that should start supporting this.